### PR TITLE
1.1.5

### DIFF
--- a/LdapTools/LdapTools.psd1
+++ b/LdapTools/LdapTools.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'LdapTools.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.0.0'
+	ModuleVersion = '1.1.5'
 	
 	# ID used to uniquely identify this module
 	GUID = '7c85477d-8f09-46f8-b62e-ddcfdc3daddf'
@@ -26,7 +26,7 @@
 	# Modules that must be imported into the global environment prior to importing
 	# this module
 	RequiredModules = @(
-		@{ ModuleName='PSFramework'; ModuleVersion='1.4.149' }
+		@{ ModuleName='PSFramework'; ModuleVersion='1.5.172' }
 	)
 	
 	# Assemblies that must be loaded prior to importing this module
@@ -40,9 +40,12 @@
 	
 	# Functions to export from this module
 	FunctionsToExport = @(
+		'Disable-LdapAccount'
+		'Enable-LdapAccount'
 		'Get-LdapGroup'
 		'Get-LdapGroupMember'
 		'Get-LdapObject'
+		'Set-LdapAccountPassword'
 		'Sync-LdapObject'	
 	)
 	

--- a/LdapTools/changelog.md
+++ b/LdapTools/changelog.md
@@ -1,5 +1,13 @@
 ﻿# Changelog
+
+## 1.1.5 (2021-03-12)
+
++ New: Command Disable-LdapAccount - disables Active Directory accounts
++ New: Command Enable-LdapAccount - enables Active Directory accounts
++ New: Command Set-LdapAccountPassword - reset the password on the target AD account.
++ Upd: Get-LdapObject - added parameter alias "SearchBase" to SearchRoot parameter for AD module compatibility.
++ Upd: Get-LdapObject - improved output object property casing
+
 ## 1.0.0 (2020-09-17)
- - New: Some Stuff
- - Upd: Moar Stuff
- - Fix: Much Stuff
+
++ Initial Release

--- a/LdapTools/en-us/strings.psd1
+++ b/LdapTools/en-us/strings.psd1
@@ -1,15 +1,23 @@
 ﻿# This is where the strings go, that are written by
 # Write-PSFMessage, Stop-PSFFunction or the PSFramework validation scriptblocks
 @{
+	'Disable-LdapAccount.AlreadyDisabled'			  = 'Account already disabled: {0} - Skipping' # $adAccount.Properties.samaccountname[0]
+	'Disable-LdapAccount.Disabling'				      = 'Disabling account {0}' # $adAccount.Properties.samaccountname[0]
+	
+	'Enable-LdapAccount.AlreadyEnabled'			      = 'Account already enabled: {0} - Skipping' # $adAccount.Properties.samaccountname[0]
+	'Enable-LdapAccount.Enabling'					  = 'Enabling account {0}' # $adAccount.Properties.samaccountname[0]
+	
 	'Get-LdapGroup.Identity.BadFormat'			      = 'Unable to identify group identifier format: {0} - make sure it''s a legal SamAccountName, DN, SID or ObjectGUID' # $groupName
 	
-	'Get-LdapGroupMember.Identity.BadFormat'		  = 'Unable to identify group identifier format: {0} - make sure it''s a legal SamAccountName, DN, SID or ObjectGUID' # $groupName
+	'Get-LdapGroupMember.Identity.BadFormat'		  = 'Unable to identify group identifier format: { 0 } - make sure it''s a legal SamAccountName, DN, SID or ObjectGUID' # $groupName
 	'Get-LdapGroupMember.Identity.GroupAccessFailure' = 'Failed to execute ldap query to resolve group: {0}!' # $groupName
 	'Get-LdapGroupMember.Identity.NotFound'		      = 'Group not found: {0}!' # $groupName
 	
 	'Get-LdapObject.SearchError'					  = 'Failed to execute ldap request.' # 
 	'Get-LdapObject.Searchfilter'					  = 'Searching with filter: {0}' # $LdapFilter
 	'Get-LdapObject.SearchRoot'					      = 'Searching {0} in {1}' # $SearchScope, $searcher.SearchRoot.Path
+	
+	'Set-LdapAccountPassword.Resetting'			      = 'Resetting the password of account {0}' # $adAccount.Properties.samaccountname[0]
 	
 	'Sync-LdapObject.DestinationAccessError'		  = 'Failed to connect to destination server {0} | {1}' # $Target, $_
 	'Sync-LdapObject.FailedReplication'			      = 'Failed to synchronize {0} from {1} to {2} | {3}' # $Object, $Server, $Target, $_

--- a/LdapTools/functions/Disable-LdapAccount.ps1
+++ b/LdapTools/functions/Disable-LdapAccount.ps1
@@ -1,0 +1,68 @@
+﻿function Disable-LdapAccount {
+<#
+	.SYNOPSIS
+		Disable an active directory account.
+	
+	.DESCRIPTION
+		Disable an active directory account.
+	
+	.PARAMETER Identity
+		Identifier specifying the account to disable.
+		Must be either SID, ObjectGuid, SamAccountName or DistinguishedName.
+	
+	.PARAMETER Server
+		The server to contact for this query.
+	
+	.PARAMETER Credential
+		The credentials to use for authenticating this query.
+	
+	.PARAMETER Confirm
+		If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+	
+	.PARAMETER WhatIf
+		If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+	
+	.EXAMPLE
+		PS C:\> Disable-LdapAccount -Identity 'peter'
+	
+		Disables the account of peter.
+#>
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	param (
+		[Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+		[string[]]
+		$Identity,
+		
+		[string]
+		$Server,
+		
+		[pscredential]
+		$Credential
+	)
+	begin {
+		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+	}
+	
+	process {
+		foreach ($identityString in $Identity) {
+			$filter = Resolve-Identity -Name $identityString -GetFilterCondition -AllowSamAccountName
+			if ($identityString -like "*,DC=*") {
+				$adAccount = Get-LdapObject @parameters -LdapFilter "(samAccountName=*)" -SearchRoot $identityString -SearchScope Base -Raw -Property UserAccountControl, samAccountName
+			}
+			else {
+				$adAccount = Get-LdapObject @parameters -LdapFilter $filter -Raw -Property UserAccountControl, samAccountName
+			}
+			
+			if (($adAccount.Properties.useraccountcontrol[0] -band 2) -ne 0) {
+				Write-PSFMessage -String 'Disable-LdapAccount.AlreadyDisabled' -StringValues $adAccount.Properties.samaccountname[0]
+				continue
+			}
+			
+			Invoke-PSFProtectedCommand -ActionString 'Disable-LdapAccount.Disabling' -ActionStringValues $adAccount.Properties.samaccountname[0] -Target $adAccount.Properties.samaccountname[0] -ScriptBlock {
+				$accountEntry = $adAccount.GetDirectoryEntry()
+				$accountEntry.userAccountControl.value = $accountEntry.userAccountControl.value -bor 2
+				$accountEntry.SetInfo()
+			} -PSCmdlet $PSCmdlet -EnableException $true -Continue
+		}
+	}
+}

--- a/LdapTools/functions/Enable-LdapAccount.ps1
+++ b/LdapTools/functions/Enable-LdapAccount.ps1
@@ -1,0 +1,68 @@
+﻿function Enable-LdapAccount {
+<#
+	.SYNOPSIS
+		Enable an active directory account.
+	
+	.DESCRIPTION
+		Enable an active directory account.
+	
+	.PARAMETER Identity
+		Identifier specifying the account to enable.
+		Must be either SID, ObjectGuid, SamAccountName or DistinguishedName.
+	
+	.PARAMETER Server
+		The server to contact for this query.
+	
+	.PARAMETER Credential
+		The credentials to use for authenticating this query.
+	
+	.PARAMETER Confirm
+		If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+	
+	.PARAMETER WhatIf
+		If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+	
+	.EXAMPLE
+		PS C:\> Enable-LdapAccount -Identity 'peter'
+	
+		Enables the account of peter.
+#>
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	param (
+		[Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+		[string[]]
+		$Identity,
+		
+		[string]
+		$Server,
+		
+		[pscredential]
+		$Credential
+	)
+	begin {
+		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+	}
+	
+	process {
+		foreach ($identityString in $Identity) {
+			$filter = Resolve-Identity -Name $identityString -GetFilterCondition -AllowSamAccountName
+			if ($identityString -like "*,DC=*") {
+				$adAccount = Get-LdapObject @parameters -LdapFilter "(samAccountName=*)" -SearchRoot $identityString -SearchScope Base -Raw -Property UserAccountControl, samAccountName
+			}
+			else {
+				$adAccount = Get-LdapObject @parameters -LdapFilter $filter -Raw -Property UserAccountControl, samAccountName
+			}
+			
+			if (($adAccount.Properties.useraccountcontrol[0] -band 2) -eq 0) {
+				Write-PSFMessage -String 'Enable-LdapAccount.AlreadyEnabled' -StringValues $adAccount.Properties.samaccountname[0]
+				continue
+			}
+			
+			Invoke-PSFProtectedCommand -ActionString 'Enable-LdapAccount.Enabling' -ActionStringValues $adAccount.Properties.samaccountname[0] -Target $adAccount.Properties.samaccountname[0] -ScriptBlock {
+				$accountEntry = $adAccount.GetDirectoryEntry()
+				$accountEntry.userAccountControl.value = $accountEntry.userAccountControl.value - ($accountEntry.userAccountControl.value -band 2)
+				$accountEntry.SetInfo()
+			} -PSCmdlet $PSCmdlet -EnableException $true -Continue
+		}
+	}
+}

--- a/LdapTools/functions/Set-LdapAccountPassword.ps1
+++ b/LdapTools/functions/Set-LdapAccountPassword.ps1
@@ -1,0 +1,71 @@
+﻿function Set-LdapAccountPassword {
+<#
+	.SYNOPSIS
+		Sets the password of an active directory account.
+	
+	.DESCRIPTION
+		Sets the password of an active directory account.
+	
+	.PARAMETER Identity
+		Identifier specifying the account to set the password for.
+		Must be either SID, ObjectGuid, SamAccountName or DistinguishedName.
+	
+	.PARAMETER Password
+		The Password to apply to the account specified
+	
+	.PARAMETER Server
+		The server to contact for this query.
+	
+	.PARAMETER Credential
+		The credentials to use for authenticating this query.
+	
+	.PARAMETER Confirm
+		If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+	
+	.PARAMETER WhatIf
+		If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+	
+	.EXAMPLE
+		PS C:\> Set-LdapAccountPassword -Identity 'peter' -Password (Read-Host -AsSecureString)
+	
+		Sets the password of peter.
+#>
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	param (
+		[Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+		[string[]]
+		$Identity,
+		
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[securestring]
+		$Password,
+		
+		[string]
+		$Server,
+		
+		[pscredential]
+		$Credential
+	)
+	begin {
+		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+	}
+	
+	process {
+		foreach ($identityString in $Identity) {
+			$filter = Resolve-Identity -Name $identityString -GetFilterCondition -AllowSamAccountName
+			if ($identityString -like "*,DC=*") {
+				$adAccount = Get-LdapObject @parameters -LdapFilter "(samAccountName=*)" -SearchRoot $identityString -SearchScope Base -Raw -Property UserAccountControl, samAccountName
+			}
+			else {
+				$adAccount = Get-LdapObject @parameters -LdapFilter $filter -Raw -Property UserAccountControl, samAccountName
+			}
+			
+			Invoke-PSFProtectedCommand -ActionString 'Set-LdapAccountPassword.Resetting' -ActionStringValues $adAccount.Properties.samaccountname[0] -Target $adAccount.Properties.samaccountname[0] -ScriptBlock {
+				$accountEntry = $adAccount.GetDirectoryEntry()
+				$cred = [PSCredential]::new("whatever", $Password)
+				$accountEntry.SetPassword($cred.GetNetworkCredential().Password)
+				$accountEntry.SetInfo()
+			} -PSCmdlet $PSCmdlet -EnableException $true -Continue
+		}
+	}
+}

--- a/LdapTools/internal/scripts/postimport.ps1
+++ b/LdapTools/internal/scripts/postimport.ps1
@@ -22,5 +22,8 @@ $moduleRoot = Split-Path (Split-Path $PSScriptRoot)
 # Load Tab Expansion Assignment
 "$moduleRoot\internal\tepp\assignment.ps1"
 
+# Load Module-Wide variable definition file
+"$moduleRoot\internal\scripts\variables.ps1"
+
 # Load License
 "$moduleRoot\internal\scripts\license.ps1"

--- a/LdapTools/internal/scripts/variables.ps1
+++ b/LdapTools/internal/scripts/variables.ps1
@@ -1,0 +1,2 @@
+﻿# Used in the module for capital-casing properties. Consumed by Get-LdapObject
+$script:culture = Get-Culture

--- a/LdapTools/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/LdapTools/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -12,7 +12,7 @@ if ($SkipTest) { return }
 $global:__pester_data.ScriptAnalyzer = New-Object System.Collections.ArrayList
 
 Describe 'Invoking PSScriptAnalyzer against commandbase' {
-	$commandFiles = Get-ChildItem -Path $CommandPath -Recurse | Where-Object Name -like "*.ps1"
+	$commandFiles = foreach ($path in $CommandPath) { Get-ChildItem -Path $path -Recurse | Where-Object Name -like "*.ps1" }
 	$scriptAnalyzerRules = Get-ScriptAnalyzerRule
 	
 	foreach ($file in $commandFiles)


### PR DESCRIPTION
+ New: Command Disable-LdapAccount - disables Active Directory accounts
+ New: Command Enable-LdapAccount - enables Active Directory accounts
+ New: Command Set-LdapAccountPassword - reset the password on the target AD account.
+ Upd: Get-LdapObject - added parameter alias "SearchBase" to SearchRoot parameter for AD module compatibility.
+ Upd: Get-LdapObject - improved output object property casing